### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "webpack-stream": "^5.0.0"
   },
   "dependencies": {
-    "gulp-run-command": "^0.0.9",
-    "npm": "^6.2.0"
+    "gulp-run-command": "^0.0.9"
   }
 }


### PR DESCRIPTION

Hello Chenzo!

It seems like you have npm as one of your (dev-) dependency in com.chenzorama.www.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
